### PR TITLE
Feature/support more field types

### DIFF
--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -142,8 +142,8 @@ class ArrayRecursiveToArray {
         throw new Exception('Unknown case in ->getTableNameByKey() for key "' . $key . '"', 1746095967);
     }
 
-    protected function processStringField(string $value, string $key): string {
-        if (!$this->tableDefinition || $this->tableDefinition->getTcaFieldDefinitionCollection()->hasField($key) === false) {
+    protected function processStringField(string $value, int|string $key): string {
+        if (!$this->tableDefinition || is_int($key) || $this->tableDefinition->getTcaFieldDefinitionCollection()->hasField($key) === false) {
             return $value;
         }
 

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -84,6 +84,9 @@ class ArrayRecursiveToArray {
                 case $value instanceof FileReference:
                     $data[$decoratedKey] = GeneralUtility::makeInstance(FileReferenceToArray::class, $value)->toArray();
                     break;
+                case $value instanceof \TYPO3\CMS\Core\Resource\Collection\LazyFolderCollection:
+                    $data[$decoratedKey] = GeneralUtility::makeInstance(LazyFolderCollectionToArray::class, $value)->toArray();
+                    break;
                 default:
                     #debug($value);
                     throw new Exception('Unknown case in ->toArray() switch for key "' . $key . '"', 1746095968);

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -15,6 +15,7 @@ use TYPO3\CMS\ContentBlocks\FieldType\JsonFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\PassFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\PasswordFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\SlugFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
 use TYPO3\CMS\Core\Collection\LazyRecordCollection;
@@ -155,6 +156,7 @@ class ArrayRecursiveToArray {
             case $fieldType instanceof TextFieldType:
             case $fieldType instanceof EmailFieldType:
             case $fieldType instanceof PassFieldType:
+            case $fieldType instanceof SlugFieldType:
                 break;
             case $fieldType instanceof PasswordFieldType:
                 $value = '';

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -12,6 +12,7 @@ use TYPO3\CMS\ContentBlocks\FieldType\CategoryFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\ColorFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\EmailFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\JsonFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\PassFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
@@ -147,6 +148,7 @@ class ArrayRecursiveToArray {
             case $fieldType instanceof SelectFieldType:
             case $fieldType instanceof TextFieldType:
             case $fieldType instanceof EmailFieldType:
+            case $fieldType instanceof PassFieldType:
                 break;
             case $fieldType instanceof TextareaFieldType:
                 $enableRichtext = $fieldType->getTca()['config']['enableRichtext'] ?? false;

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\ContentBlocks\Definition\TableDefinition;
 use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 use TYPO3\CMS\ContentBlocks\FieldType\CategoryFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\ColorFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\EmailFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
@@ -136,6 +137,7 @@ class ArrayRecursiveToArray {
             case $fieldType instanceof ColorFieldType:
             case $fieldType instanceof SelectFieldType:
             case $fieldType instanceof TextFieldType:
+            case $fieldType instanceof EmailFieldType:
                 break;
             case $fieldType instanceof TextareaFieldType:
                 $enableRichtext = $fieldType->getTca()['config']['enableRichtext'] ?? false;

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -44,6 +44,7 @@ class ArrayRecursiveToArray {
 
             switch (true) {
                 case is_null($value):
+                case is_int($value):
                     $data[$decoratedKey] = $value;
                     break;
                 case is_array($value):
@@ -78,6 +79,7 @@ class ArrayRecursiveToArray {
                     $data[$decoratedKey] = GeneralUtility::makeInstance(FileReferenceToArray::class, $value)->toArray();
                     break;
                 default:
+                    debug($value);
                     throw new Exception('Unknown case in ->toArray() switch for key "' . $key . '"', 1746095968);
             }
         }

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -63,8 +63,13 @@ class ArrayRecursiveToArray {
                     $data[$decoratedKey] = GeneralUtility::makeInstance(TypolinkParameterToArray::class, $value)->toArray();
                     break;
                 case $value instanceof LazyRecordCollection:
-                    $tableDefinition = $this->getTableDefinitionByKey($key);
-                    $data[$decoratedKey] = GeneralUtility::makeInstance(LazyRecordCollectionToArray::class, $value, $tableDefinition, $this->tableDefinitionCollection)->toArray();
+                    $tableName = $this->getTableNameByKey($key);
+                    if ($tableName === 'sys_category') {
+                        $data[$decoratedKey] = GeneralUtility::makeInstance(LazyRecordCollectionSysCategoryToArray::class, $value)->toArray();
+                    } else {
+                        $tableDefinition = $this->getTableDefinitionByKey($key);
+                        $data[$decoratedKey] = GeneralUtility::makeInstance(LazyRecordCollectionToArray::class, $value, $tableDefinition, $this->tableDefinitionCollection)->toArray();
+                    }
                     break;
                 case $value instanceof LazyFileReferenceCollection:
                     $data[$decoratedKey] = GeneralUtility::makeInstance(LazyFileReferenceCollectionToArray::class, $value)->toArray();
@@ -74,8 +79,6 @@ class ArrayRecursiveToArray {
                     break;
                 default:
                     throw new Exception('Unknown case in ->toArray() switch for key "' . $key . '"', 1746095968);
-                #$data[$decoratedKey] = $value;
-                #break;
             }
         }
 

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -130,14 +130,19 @@ class ArrayRecursiveToArray {
             }
 
             $tca = $fieldType->getTca();
-            return $tca['config']['foreign_table'];
+            if (isset($tca['config']['foreign_table'])) {
+                return $tca['config']['foreign_table'];
+            }
+            if (isset($tca['config']['allowed'])) {
+                return $tca['config']['allowed'];
+            }
         }
 
         throw new Exception('Unknown case in ->getTableNameByKey() for key "' . $key . '"', 1746095967);
     }
 
     protected function processStringField(string $value, string $key): string {
-        if ($this->tableDefinition->getTcaFieldDefinitionCollection()->hasField($key) === false) {
+        if (!$this->tableDefinition || $this->tableDefinition->getTcaFieldDefinitionCollection()->hasField($key) === false) {
             return $value;
         }
 

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 use TYPO3\CMS\ContentBlocks\FieldType\CategoryFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\ColorFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\EmailFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\JsonFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
@@ -19,6 +20,7 @@ use TYPO3\CMS\Core\Domain\FlexFormFieldValues;
 use TYPO3\CMS\Core\Domain\Record;
 use TYPO3\CMS\Core\LinkHandling\TypolinkParameter;
 use TYPO3\CMS\Core\Resource\Collection\LazyFileReferenceCollection;
+use TYPO3\CMS\Core\Resource\Collection\LazyFolderCollection;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -51,12 +53,16 @@ class ArrayRecursiveToArray {
                     $data[$decoratedKey] = $value;
                     break;
                 case is_array($value):
-                    $data[$decoratedKey] = GeneralUtility::makeInstance(ArrayRecursiveToArray::class, $value)->toArray();
+                    if ($tcaFieldDefinition && $tcaFieldDefinition->getFieldType() instanceof JsonFieldType) {
+                        $data[$decoratedKey] = $value;
+                    } else {
+                        $data[$decoratedKey] = GeneralUtility::makeInstance(ArrayRecursiveToArray::class, $value, null, $this->tableDefinitionCollection)->toArray();
+                    }
                     break;
                 case is_string($value):
                     $data[$decoratedKey] = $this->processStringField($value, $key);
                     break;
-                case $value instanceof DateTimeImmutable: 
+                case $value instanceof DateTimeImmutable:
                     $data[$decoratedKey] = $value->format(DateTimeImmutable::W3C);
                     break;
                 case $value instanceof Record:
@@ -84,7 +90,7 @@ class ArrayRecursiveToArray {
                 case $value instanceof FileReference:
                     $data[$decoratedKey] = GeneralUtility::makeInstance(FileReferenceToArray::class, $value)->toArray();
                     break;
-                case $value instanceof \TYPO3\CMS\Core\Resource\Collection\LazyFolderCollection:
+                case $value instanceof LazyFolderCollection:
                     $data[$decoratedKey] = GeneralUtility::makeInstance(LazyFolderCollectionToArray::class, $value)->toArray();
                     break;
                 default:

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Netzbewegung\NbHeadlessContentBlocks\DataProcessing\ToArray;
 
+use DateTimeImmutable;
 use Exception;
 use TYPO3\CMS\ContentBlocks\Definition\TableDefinition;
 use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 use TYPO3\CMS\ContentBlocks\FieldType\CategoryFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\ColorFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
@@ -53,6 +55,9 @@ class ArrayRecursiveToArray {
                 case is_string($value):
                     $data[$decoratedKey] = $this->processStringField($value, $key);
                     break;
+                case $value instanceof DateTimeImmutable: 
+                    $data[$decoratedKey] = $value->format(DateTimeImmutable::W3C);
+                    break;
                 case $value instanceof Record:
                     $tableDefinition = $this->getTableDefinitionByKey($key);
                     $data[$decoratedKey] = GeneralUtility::makeInstance(RecordToArray::class, $value, $tableDefinition, $this->tableDefinitionCollection)->toArray();
@@ -79,7 +84,7 @@ class ArrayRecursiveToArray {
                     $data[$decoratedKey] = GeneralUtility::makeInstance(FileReferenceToArray::class, $value)->toArray();
                     break;
                 default:
-                    debug($value);
+                    #debug($value);
                     throw new Exception('Unknown case in ->toArray() switch for key "' . $key . '"', 1746095968);
             }
         }
@@ -128,7 +133,7 @@ class ArrayRecursiveToArray {
         $fieldType = $tcaFieldDefinition->getFieldType();
 
         switch (true) {
-            #case $fieldType instanceof FileFieldType;
+            case $fieldType instanceof ColorFieldType:
             case $fieldType instanceof SelectFieldType:
             case $fieldType instanceof TextFieldType:
                 break;
@@ -141,6 +146,7 @@ class ArrayRecursiveToArray {
 
                 break;
             default:
+                #debug($fieldType);
                 throw new Exception('Unknown default case in ArrayRecursiveToArray default case for key "' . $key . '"', 1746095966);
         }
 

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\ContentBlocks\FieldType\ColorFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\EmailFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\JsonFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\PassFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\PasswordFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
@@ -149,6 +150,9 @@ class ArrayRecursiveToArray {
             case $fieldType instanceof TextFieldType:
             case $fieldType instanceof EmailFieldType:
             case $fieldType instanceof PassFieldType:
+                break;
+            case $fieldType instanceof PasswordFieldType:
+                $value = '';
                 break;
             case $fieldType instanceof TextareaFieldType:
                 $enableRichtext = $fieldType->getTca()['config']['enableRichtext'] ?? false;

--- a/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
+++ b/Classes/DataProcessing/ToArray/ArrayRecursiveToArray.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SlugFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\UuidFieldType;
 use TYPO3\CMS\Core\Collection\LazyRecordCollection;
 use TYPO3\CMS\Core\Domain\FlexFormFieldValues;
 use TYPO3\CMS\Core\Domain\Record;
@@ -157,6 +158,7 @@ class ArrayRecursiveToArray {
             case $fieldType instanceof EmailFieldType:
             case $fieldType instanceof PassFieldType:
             case $fieldType instanceof SlugFieldType:
+            case $fieldType instanceof UuidFieldType:
                 break;
             case $fieldType instanceof PasswordFieldType:
                 $value = '';

--- a/Classes/DataProcessing/ToArray/LazyFolderCollectionToArray.php
+++ b/Classes/DataProcessing/ToArray/LazyFolderCollectionToArray.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Netzbewegung\NbHeadlessContentBlocks\DataProcessing\ToArray;
+
+use TYPO3\CMS\Core\Resource\Collection\LazyFolderCollection;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class LazyFolderCollectionToArray
+{
+
+    public function __construct(protected LazyFolderCollection $lazyFolderCollection)
+    {
+        
+    }
+
+    public function toArray(): array
+    {
+        $data = [];
+        foreach ($this->lazyFolderCollection as $key => $value) {
+            $path = '/' . $value->getStorage()->getConfiguration()['basePath'] . ltrim($value->getIdentifier(), '/');
+            $data[$key] = $path;
+        }
+
+        return $data;
+    }
+}

--- a/Classes/DataProcessing/ToArray/LazyRecordCollectionSysCategoryToArray.php
+++ b/Classes/DataProcessing/ToArray/LazyRecordCollectionSysCategoryToArray.php
@@ -8,13 +8,11 @@ use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 use TYPO3\CMS\Core\Collection\LazyRecordCollection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-class LazyRecordCollectionToArray
+class LazyRecordCollectionSysCategoryToArray
 {
 
     public function __construct(
         protected LazyRecordCollection $lazyRecordCollection,
-        protected ?TableDefinition $tableDefinition,
-        protected TableDefinitionCollection $tableDefinitionCollection
     )
     {
         
@@ -25,7 +23,12 @@ class LazyRecordCollectionToArray
         $data = [];
 
         foreach ($this->lazyRecordCollection as $key => $value) {
-            $data[$key] = GeneralUtility::makeInstance(RecordToArray::class, $value, $this->tableDefinition, $this->tableDefinitionCollection)->toArray();
+            $array = $value->toArray();
+            $data[$key] = [
+                'uid' => $array['uid'],
+                'pid' => $array['pid'],
+                'title' => $array['title'],
+            ];
         }
 
         return $data;

--- a/Classes/DataProcessing/ToArray/LazyRecordCollectionToArray.php
+++ b/Classes/DataProcessing/ToArray/LazyRecordCollectionToArray.php
@@ -13,7 +13,7 @@ class LazyRecordCollectionToArray
 
     public function __construct(
         protected LazyRecordCollection $lazyRecordCollection,
-        protected TableDefinition $tableDefinition,
+        protected ?TableDefinition $tableDefinition,
         protected TableDefinitionCollection $tableDefinitionCollection
     )
     {

--- a/Classes/DataProcessing/ToArray/RecordToArray.php
+++ b/Classes/DataProcessing/ToArray/RecordToArray.php
@@ -14,7 +14,7 @@ class RecordToArray
 
     public function __construct(
         protected Record $record,
-        protected TableDefinition $tableDefinition,
+        protected ?TableDefinition $tableDefinition,
         protected TableDefinitionCollection $tableDefinitionCollection
     )
     {


### PR DESCRIPTION
Add support for field types:

- `type: Uuid`
- `type: Select` with `renderType: selectMultipleSideBySide`
- `type: Slug`
- `type: Relation` (only one table in allowed)
- `type: Password` 
- `type: Pass` (TCA passthrough)
- `type: Json`
- `type: Folder`  (We only return the path to the folder including storage basePath).
- `type: Email`
- `type: DateTime`
- `type: Checkbox` (with int values)
- `type: Category`